### PR TITLE
Cast `relation_column` and `relation_column_type` to string type

### DIFF
--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_type_list.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_type_list.sql
@@ -8,8 +8,8 @@
 
         {% for column in columns_in_relation %}
         select
-            '{{ column.name | upper }}' as relation_column,
-            '{{ column.dtype | upper }}' as relation_column_type
+            cast('{{ column.name | upper }}' as {{ dbt_utils.type_string() }}) as relation_column,
+            cast('{{ column.dtype | upper }}' as {{ dbt_utils.type_string() }}) as relation_column_type
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     ),


### PR DESCRIPTION
In some circumstances, Redshift will fail to execute queries generated by `expect_column_values_to_be_in_type_list` if it is unable infer the type of the `relation_column` or `relation_column_type` fields. 

```
[2021-12-06 10:59:13] [XX000] ERROR: failed to find conversion function from "unknown" to text
```

This PR updates enforces a casting of those values to a string type to prevent ambiguity.

A related defect has been resolved in https://github.com/calogica/dbt-expectations/pull/101/files